### PR TITLE
Revert "[BEAM-13176] [Playground] Add new argument to NewNetworkEnv in env service tests"

### DIFF
--- a/playground/backend/internal/environment/environment_service_test.go
+++ b/playground/backend/internal/environment/environment_service_test.go
@@ -159,8 +159,8 @@ func Test_getNetworkEnvsFromOsEnvs(t *testing.T) {
 		},
 		{
 			name:      "values from os envs",
-			want:      NewNetworkEnvs("12.12.12.21", 1234, "TCP"),
-			envsToSet: map[string]string{serverIpKey: "12.12.12.21", serverPortKey: "1234", protocolTypeKey: "TCP"},
+			want:      NewNetworkEnvs("12.12.12.21", 1234, defaultProtocol),
+			envsToSet: map[string]string{serverIpKey: "12.12.12.21", serverPortKey: "1234"},
 		},
 		{
 			name:      "not int port in os env, should be default",


### PR DESCRIPTION
Reverts akvelon/beam#74